### PR TITLE
changes branch and version to master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN set -x \
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 ENV MAPBENDER_REPOSITORY "https://github.com/mapbender/mapbender-starter.git"
-ENV MAPBENDER_BRANCH "release/3.0.6"
+ENV MAPBENDER_BRANCH "master"
 ENV MAPBENDER_NAME "mapbender"
-ENV MAPBENDER_VERSION "3.0.6"
+ENV MAPBENDER_VERSION "master"
 ENV BUILD_NUMBER 1
 
 # bob the builder


### PR DESCRIPTION
* choosed easiest way to ge the latest code
* nicer soluton would be to always take the default branch if not set
* MAPBENDER_VERSION "master" not very elegant but better than release/3.0.6